### PR TITLE
BrowserUtils: add the possibility to open URLs instead of Strings.

### DIFF
--- a/ret-core/src/main/kotlin/io/rabobank/ret/util/BrowserUtils.kt
+++ b/ret-core/src/main/kotlin/io/rabobank/ret/util/BrowserUtils.kt
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.apache.commons.lang3.SystemUtils.IS_OS_LINUX
 import org.apache.commons.lang3.SystemUtils.IS_OS_MAC
 import org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS
+import java.net.URL
 
 /**
  * Utils to open a Browser
@@ -22,6 +23,13 @@ class BrowserUtils {
             IS_OS_LINUX -> throw NotImplementedError("Linux support is not available yet.")
             IS_OS_MAC -> openUrlMacOs(url)
         }
+    }
+
+    /**
+     * Open the provided [url] in a browser.
+     */
+    fun openUrl(url: URL) {
+        openUrl(url.toString())
     }
 
     private fun openUrlWindows(url: String) {


### PR DESCRIPTION
We want to change the [GitUrlFactory in the git-plugin to return URLs](https://github.com/rabobank/ret-plugins/pull/30#discussion_r1247509033), but I noticed I still had to provide Strings to the BrowserUtils. This looked like a logical next step to me.

We can possibly deprecate the String method.