### PR TITLE
Allow primitive option types

### DIFF
--- a/ret-cli/src/main/kotlin/io/rabobank/ret/plugins/PluginLoader.kt
+++ b/ret-cli/src/main/kotlin/io/rabobank/ret/plugins/PluginLoader.kt
@@ -62,7 +62,7 @@ class PluginLoader(
         command.options.forEach {
             commandSpec.addOption(
                 OptionSpec.builder(it.names.toTypedArray())
-                    .type(Class.forName(it.type))
+                    .type(asType(it.type))
                     .completionCandidates(it.completionCandidates)
                     .build(),
             )
@@ -82,4 +82,33 @@ class PluginLoader(
             executionContext.repositoryName(),
             executionContext.branchName(),
         )
+
+    private companion object {
+        /**
+         * Return the java [java.lang.Class] object with the specified class name.
+         *
+         * This is an "extended" [java.lang.Class.forName] operation.
+         *
+         * + It is able to return Class objects for primitive types
+         * + Classes in name space `java.lang` do not need the fully qualified name
+         * + It does not throw a checked Exception
+         *
+         * @param className The class name, never `null`
+         *
+         * @throws IllegalArgumentException if no class can be loaded
+         */
+        private fun asType(className: String): Class<*>? =
+            when (className) {
+                "boolean" -> Boolean::class.javaPrimitiveType
+                "byte" -> Byte::class.javaPrimitiveType
+                "short" -> Short::class.javaPrimitiveType
+                "int" -> Int::class.javaPrimitiveType
+                "long" -> Long::class.javaPrimitiveType
+                "float" -> Float::class.javaPrimitiveType
+                "double" -> Double::class.javaPrimitiveType
+                "char" -> Char::class.javaPrimitiveType
+                "void" -> Void.TYPE
+                else -> Class.forName(if (className.contains(".")) className else "java.lang.$className")
+            }
+    }
 }

--- a/ret-cli/src/main/kotlin/io/rabobank/ret/plugins/RetPlugin.java
+++ b/ret-cli/src/main/kotlin/io/rabobank/ret/plugins/RetPlugin.java
@@ -2,11 +2,13 @@ package io.rabobank.ret.plugins;
 
 public final class RetPlugin {
 
-    private RetPlugin(){
+    private RetPlugin() {
 
     }
 
     public static native long createIsolate();
+
     public static native void invoke(long isolateId, String retContext);
+
     public static native void initialize(long isolateId, String plugin);
 }

--- a/ret-core/pom.xml
+++ b/ret-core/pom.xml
@@ -56,10 +56,6 @@
                 <artifactId>jandex-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>io.quarkus.platform</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
             </plugin>

--- a/ret-plugin/pom.xml
+++ b/ret-plugin/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.github.rabobank</groupId>
@@ -86,10 +87,6 @@
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>io.quarkus.platform</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
When a `Boolean` is used in Kotlin this is translated to a primitive `boolean` in Java. When it tries to add this type of option it fails to instantiate such a class.