### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -143,7 +143,7 @@ jobs:
                     git checkout --progress --force refs/tags/${{ github.event.inputs.version }}
 
             -   name: 'Download all build artifacts'
-                uses: actions/download-artifact@v4
+                uses: actions/download-artifact@v3
 
             -   name: 'Set up Java'
                 uses: actions/setup-java@v4


### PR DESCRIPTION
This reverts commit 495cc270b4b91a0480186f6a6cf95c2f4a71ef6d.

See https://github.com/actions/upload-artifact/issues/478