### PR TITLE
No more need for native-image component, it's automatically included

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -72,7 +72,6 @@ jobs:
                 with:
                     distribution: 'graalvm'
                     java-version: ${{ env.JAVA_VERSION }}
-                    components: 'native-image'
                     github-token: ${{ secrets.GITHUB_TOKEN }}
 
             -   name: 'Cache Maven packages'


### PR DESCRIPTION
Fixes:
> Warning: Please remove "components: 'native-image'" from your workflow file. It is automatically included since GraalVM for JDK 17: https://github.com/oracle/graal/pull/5995